### PR TITLE
Fix docker-compose.yaml error

### DIFF
--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -6,9 +6,7 @@ services:
     ports:
       - "0.0.0.0:4000:4000"
     volumes:
-      - type: bind
-        source: ./config.json
-        target: /app/config.json
+      - ./config.json:/app/config.json
       - node-logs:/logs
       - /var/run/docker.sock:/var/run/docker.sock
     networks:


### PR DESCRIPTION
Switching from dictionary to array for node:volumes to fix the following error:

> services.node.volumes contains an invalid type, it should be a string