### PR TITLE
Fix Dockerfile "ADD --chmod" does not work

### DIFF
--- a/projects/gpt4/container/Dockerfile
+++ b/projects/gpt4/container/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update
 RUN apt-get install -y git curl
 
 # install uv
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD https://astral.sh/uv/install.sh /install.sh
+RUN chmod 755 /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY src/requirements.txt .

--- a/projects/hello-world/container/Dockerfile
+++ b/projects/hello-world/container/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update
 RUN apt-get install -y git curl
 
 # install uv
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD https://astral.sh/uv/install.sh /install.sh
+RUN chmod 755 /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY src/requirements.txt .

--- a/projects/onnx-iris/container/Dockerfile
+++ b/projects/onnx-iris/container/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update
 RUN apt-get install -y git curl
 
 # install uv
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD https://astral.sh/uv/install.sh /install.sh
+RUN chmod 755 /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY src/requirements.txt .

--- a/projects/prompt-to-nft/container/Dockerfile
+++ b/projects/prompt-to-nft/container/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update
 RUN apt-get install -y git curl
 
 # install uv
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD https://astral.sh/uv/install.sh /install.sh
+RUN chmod 755 /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY src/requirements.txt .

--- a/projects/prompt-to-nft/stablediffusion/Dockerfile
+++ b/projects/prompt-to-nft/stablediffusion/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update
 RUN apt-get install -y git curl ffmpeg libsm6 libxext6
 
 # install uv
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD https://astral.sh/uv/install.sh /install.sh
+RUN chmod 755 /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY src/requirements.txt .

--- a/projects/tgi-llm/container/Dockerfile
+++ b/projects/tgi-llm/container/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update
 RUN apt-get install -y git curl
 
 # install uv
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD https://astral.sh/uv/install.sh /install.sh
+RUN chmod 755 /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY src/requirements.txt .

--- a/projects/torch-iris/container/Dockerfile
+++ b/projects/torch-iris/container/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update
 RUN apt-get install -y git curl
 
 # install uv
-ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+ADD https://astral.sh/uv/install.sh /install.sh
+RUN chmod 755 /install.sh
 RUN /install.sh && rm /install.sh
 
 COPY src/requirements.txt .


### PR DESCRIPTION
Hi, I just noticed the command "ADD --chmod" in the Dockerfile did not work when I was building the image. Somehow the file permission wasn't updated as expected, and the subsequent use of the file would lead to permission denied.

Not sure if it's the best solution, but it works for me