### PR TITLE
Add snapshot sync config

### DIFF
--- a/projects/hello-world/container/config.json
+++ b/projects/hello-world/container/config.json
@@ -13,6 +13,10 @@
       "private_key": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
     }
   },
+  "snapshot_sync": {
+    "sleep": 5,
+    "batch_size": 100
+  },
   "startup_wait": 1.0,
   "docker": {
     "username": "your-username",


### PR DESCRIPTION
This PR adds an important part of the configuration file, which had been omitted in one of the files.

This configuration helps the user to define the batch size of requests to the RPC provider, and thus avoid 429 errors.