### PR TITLE
fix: omit payment address

### DIFF
--- a/projects/gpt4/container/config.sample.json
+++ b/projects/gpt4/container/config.sample.json
@@ -15,7 +15,6 @@
     "wallet": {
       "max_gas_limit": 4000000,
       "private_key": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-      "payment_address": "",
       "allowed_sim_errors": []
     },
     "snapshot_sync": {

--- a/projects/hello-world/container/config.json
+++ b/projects/hello-world/container/config.json
@@ -15,7 +15,6 @@
         "wallet": {
             "max_gas_limit": 4000000,
             "private_key": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-            "payment_address": "",
             "allowed_sim_errors": []
         },
         "snapshot_sync": {

--- a/projects/onnx-iris/container/config.json
+++ b/projects/onnx-iris/container/config.json
@@ -15,7 +15,6 @@
         "wallet": {
             "max_gas_limit": 4000000,
             "private_key": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-            "payment_address": "",
             "allowed_sim_errors": []
         },
         "snapshot_sync": {

--- a/projects/prompt-to-nft/container/config.sample.json
+++ b/projects/prompt-to-nft/container/config.sample.json
@@ -15,7 +15,6 @@
         "wallet": {
             "max_gas_limit": 4000000,
             "private_key": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-            "payment_address": "",
             "allowed_sim_errors": []
         },
         "snapshot_sync": {

--- a/projects/tgi-llm/container/config.sample.json
+++ b/projects/tgi-llm/container/config.sample.json
@@ -15,7 +15,6 @@
         "wallet": {
             "max_gas_limit": 4000000,
             "private_key": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-            "payment_address": "",
             "allowed_sim_errors": []
         },
         "snapshot_sync": {

--- a/projects/torch-iris/container/config.json
+++ b/projects/torch-iris/container/config.json
@@ -15,7 +15,6 @@
         "wallet": {
             "max_gas_limit": 4000000,
             "private_key": "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-            "payment_address": "",
             "allowed_sim_errors": []
         },
         "snapshot_sync": {


### PR DESCRIPTION
# Overview
This PR fixes a recently introduced issue. Setting `payment_address` to an empty string causes the node to break. This will get fixed in the next release. 